### PR TITLE
Add support for Magnify

### DIFF
--- a/Compat/Compat.lua
+++ b/Compat/Compat.lua
@@ -1063,7 +1063,8 @@ QuestieCompat.KButtons = {
     Add = function(self, templateName, templateType)
         local button = CreateFrame("Button", "Questie_WorldMapButton", WorldMapFrame)
         button:SetHighlightTexture("Interface\\Minimap\\UI-Minimap-ZoomButton-Highlight")
-        button:SetPoint("TOPRIGHT", WorldMapButton, "TOPRIGHT", -4, -2);
+        -- Support WorldMapScrollFrame for Magnify if present
+        button:SetPoint("TOPRIGHT", WorldMapScrollFrame or WorldMapButton, "TOPRIGHT", -4, -2);
         button:SetFrameLevel(99)
         button:SetSize(32, 32)
         button:RegisterForClicks("anyUp")

--- a/Modules/FramePool/QuestieFrame.lua
+++ b/Modules/FramePool/QuestieFrame.lua
@@ -41,12 +41,6 @@ function QuestieFramePool.Qframe:New(frameId, OnEnter)
         Questie:Debug(Questie.DEBUG_CRITICAL, "[QuestieFramePool] Over 5000 frames... maybe there is a leak?", frameId)
     end
 
-    newFrame.glow = CreateFrame("Button", "QuestieFrame" .. frameId .. "Glow", newFrame) -- glow frame
-    newFrame.glow:SetFrameStrata("FULLSCREEN");
-    newFrame.glow:SetWidth(18)                                                           -- Set these to whatever height/width is needed
-    newFrame.glow:SetHeight(18)
-
-
     newFrame:SetFrameStrata("FULLSCREEN");
     newFrame:SetWidth(16)  -- Set these to whatever height/width is needed
     newFrame:SetHeight(16) -- for your Texture
@@ -65,10 +59,11 @@ function QuestieFramePool.Qframe:New(frameId, OnEnter)
         newTexture:SetSnapToPixelGrid(false)
     end
 
-    local glowt = newFrame.glow:CreateTexture(nil, "OVERLAY", nil, -1)
+    local glowt = newFrame:CreateTexture(nil, "BACKGROUND", nil, -1)
     glowt:SetWidth(18)
     glowt:SetHeight(18)
-    glowt:SetAllPoints(newFrame.glow)
+    glowt:SetAllPoints(newFrame)
+    newFrame.glow = glowt
 
     ---@class IconTexture : Texture
     newFrame.texture = newTexture;
@@ -102,7 +97,6 @@ function QuestieFramePool.Qframe:New(frameId, OnEnter)
     newFrame.glowTexture:SetTexture(Questie.icons["glow"])
     newFrame.glow:Hide()
     newFrame.glow:SetPoint("CENTER", -9, -9) -- 2 pixels bigger than normal icon
-    newFrame.glow:EnableMouse(false)
 
     newFrame:SetScript("OnEnter", OnEnter);        --Script Toolip
     newFrame:SetScript("OnLeave", _Qframe.OnLeave) --Script Exit Tooltip
@@ -261,10 +255,6 @@ function _Qframe:BaseOnShow()
         local _, _, _, alpha = self.texture:GetVertexColor()
         self.glowTexture:SetVertexColor(data.ObjectiveData.Color[1], data.ObjectiveData.Color[2], data.ObjectiveData.Color[3], alpha or 1)
         self.glow:Show()
-        local frameLevel = self:GetFrameLevel()
-        if frameLevel > 0 then
-            self.glow:SetFrameLevel(frameLevel - 1)
-        end
     end
 end
 

--- a/Modules/Map/QuestieMapUtils.lua
+++ b/Modules/Map/QuestieMapUtils.lua
@@ -24,9 +24,10 @@ function QuestieMap.utils:SetDrawOrder(frame)
         frame:SetFrameStrata(frameStrata)
         frame:SetFrameLevel(frameLevel)
     else
-        local frameLevel = WorldMapFrame:GetFrameLevel() + 7
-        local frameStrata = WorldMapFrame:GetFrameStrata()
-        frame:SetParent(WorldMapFrame)
+        local canvas = QuestieCompat.WorldMapFrame.GetCanvas()
+        local frameLevel = canvas:GetFrameLevel() + 7
+        local frameStrata = canvas:GetFrameStrata()
+        frame:SetParent(canvas)
         frame:SetFrameStrata(frameStrata)
         frame:SetFrameLevel(frameLevel)
     end

--- a/Questie.lua
+++ b/Questie.lua
@@ -22,9 +22,6 @@ function Questie:OnInitialize()
     -- This has to happen OnInitialize to be available asap
     Questie.db = LibStub("AceDB-3.0"):New("QuestieConfig", QuestieOptionsDefaults:Load(), true)
 
-    -- Initialize essential tracker tables immediately to prevent race conditions with quest events
-    QuestieTracker.InitializeTables()
-
     -- These events basically all mean the same: The active profile changed.
     Questie.db.RegisterCallback(Questie, "OnProfileChanged", "RefreshConfig")
     Questie.db.RegisterCallback(Questie, "OnProfileCopied", "RefreshConfig")


### PR DESCRIPTION
This adds support for https://github.com/rissole/Magnify-WotLK by:

- Anchoring the world map button to the scroll frame so it doesn't fly off when zooming
- Setting the quest icon parent to WorldMapButton (the "canvas") during SetDrawOrder, which scales correctly
- Changing the quest icon glow to a single texture instead of a frame, due to stacking issues when the icons were rendered within a scrollframe.

Also included is  the removal of `QuestieTracker.InitializeTables()` referenced in #26 #27 #29 #31 

Fixes #28 

## QA

**Magnify enabled**
- [x] Quest icons appear as expected and zoom correctly, including glow
- [x] Quest lines look good and zoom correctly
- [x] World map button is present and is fixed in the top right of the frame

**Magnify disabled**
- [x] Quest icons, glow, and lines appear as normal
- [x] World map button is present and is fixed in the top right of the frame