### PR TITLE
Fix tooltips not appearing in full screen map + mini vanilla map

### DIFF
--- a/Compat/Compat.lua
+++ b/Compat/Compat.lua
@@ -888,7 +888,9 @@ end
 
 -- handle tooltip based on the parent frame
 function QuestieCompat.SetupTooltip(frame, OnHide)
-    if (frame:GetParent() == WorldMapFrame) then
+    -- The parent frame can be "WorldMapFrame" or "WorldMapButton", so check if the parent starts with the WorldMap prefix
+    local worldMapPrefix = "WorldMap"
+    if (frame:GetParent():GetName():sub(0, #worldMapPrefix) == worldMapPrefix) then
         WorldMapPOIFrame.allowBlobTooltip = OnHide and true or false
         QuestieCompat.Tooltip = WorldMapTooltip
     else

--- a/Modules/Map/QuestieMapUtils.lua
+++ b/Modules/Map/QuestieMapUtils.lua
@@ -24,7 +24,8 @@ function QuestieMap.utils:SetDrawOrder(frame)
         frame:SetFrameStrata(frameStrata)
         frame:SetFrameLevel(frameLevel)
     else
-        local canvas = QuestieCompat.WorldMapFrame.GetCanvas()
+        -- If Magnify present, anchor to the scalable canvas; otherwise anchor to the vanilla WorldMapFrame
+        local canvas = WorldMapScrollFrame and QuestieCompat.WorldMapFrame.GetCanvas() or WorldMapFrame
         local frameLevel = canvas:GetFrameLevel() + 7
         local frameStrata = canvas:GetFrameStrata()
         frame:SetParent(canvas)


### PR DESCRIPTION
[Users report](https://discord.com/channels/729423227373355040/1408826807167352865/1410172908164087929) since #33 that tooltips were no longer appearing in the full screen map.

This is because the tooltip logic checked if the frames were parented to WorldMapFrame. This is no longer the case since #33 - they are parented to WorldMapButton which scales correctly in Magnify. The tooltip was updated to account for both cases.

Secondly, [another report](https://discord.com/channels/729423227373355040/1408826807167352865/1410173825286672464) showed that minimized vanilla map rendered icons in the wrong location. This is because WorldMapButton isn't scaled without Magnify, so we must parent to WorldMapFrame as it originally did, in the case where map canvas-level scaling isn't supported.

## QA

- [x] No Magnify: Fullscreen map shows tooltips
- [x] No Magnify: Minimized map has icons in the right positions
- [x] With Magnify: tooltips work, map icons in the right positions.

Apologies for introducing the bug!