### PR TITLE
Maintain icon scale on map zoom

### DIFF
--- a/Modules/Map/QuestieMap.lua
+++ b/Modules/Map/QuestieMap.lua
@@ -207,6 +207,7 @@ function QuestieMap.GetScaleValue()
         elseif (mapInfo.mapType == 2) then -- Continent
             scaling = 0.9
         end
+        scaling = scaling / WorldMapDetailFrame:GetScale()
     end
     return scaling
 end

--- a/Modules/QuestieEventHandler.lua
+++ b/Modules/QuestieEventHandler.lua
@@ -223,6 +223,9 @@ function QuestieEventHandler:RegisterLateEvents()
             end
         end
     end)
+
+    -- Maintain icon scale when map zoom changes
+    hooksecurefunc(WorldMapDetailFrame, "SetScale", QuestieMap.RescaleIcons)
 end
 
 function _EventHandler:PlayerLogin()


### PR DESCRIPTION
I wanted this feature for myself and figured I'd share it in case anyone else likes this behavior. There's probably a better way/place to implement it but I'm not familiar enough with Questie's structure and it works for me for now.

This makes it so that when you zoom in on the map, the icons retain their size relative to the screen instead of scaling up with the map. In this way if you have a bunch of icons all overlapping in an area on the map, you can zoom in (using addons like Magnify) to spread them out and get a better view of what's in that area and make it easier to hover over the icon(s) you're interested in.

Example:
<img width="1000" height="400" alt="MagnifyQuestie" src="https://github.com/user-attachments/assets/ae40df81-855e-48e2-8bac-7e11f81d52fb" />


I love Magnify, but without this I find it to be much less helpful since zooming in doesn't really make things any easier for me. Magnify does perform this function for native icons like the player arrow, but understandably not for icons added by other addons such as pfQuest, Questie, Gatherer, etc.